### PR TITLE
rbac: add DRA granular status authorization rules for node-local driver

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -34,6 +34,15 @@ rules:
     verbs:
       - patch
       - update
+  - apiGroups:
+      - "resource.k8s.io"
+    resources:
+      - resourceclaims/driver
+    verbs:
+      - associated-node:update
+      - associated-node:patch
+    resourceNames:
+      - dravip
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Starting in Kubernetes v1.36, the `DRAResourceClaimGranularStatusAuthorization` feature gate (beta, on-by-default) enforces fine-grained authorization checks for `ResourceClaim` status updates.

Node-local DRA drivers now require additional permissions on the `resourceclaims/driver` synthetic subresource with `associated-node:update` and `associated-node:patch` verbs.

This adds the required RBAC rule to the `dravip` DaemonSet ClusterRole, scoped to the driver name `dravip`. The controller Deployment ClusterRole does not write to `resourceclaims/status` and is not affected.

These new permissions are inert on Kubernetes versions prior to v1.36.

Ref: kubernetes/kubernetes#138149